### PR TITLE
data prep from GLS Bank and automatic encoding cmxl

### DIFF
--- a/lib/fints/helper.rb
+++ b/lib/fints/helper.rb
@@ -7,10 +7,10 @@ module FinTS
     def self.fints_unescape(content)
       content.gsub('??', '?').gsub("?'", "'").gsub('?+', '+').gsub('?:', ':')
     end
-    
+
     def self.mt940_to_array(data)
-      processed_data = data.gsub('@@', '\r\n').gsub('-0000', '+0000')
-      mt940 = Cmxl.parse(processed_data, encoding: 'ISO-8859-1')
+      processed_data = data.gsub('@@', "\n").gsub('-0000', '+0000')
+      mt940 = Cmxl.parse(processed_data)
       mt940.flat_map(&:transactions)
     end
   end


### PR DESCRIPTION
For GLS Bank mt940_to_array helper should replace the @@ to a real line break. 
(I'm not sure how the string \r\n ever worked with Linux)

Additionally the encoding  was not correct on Ubuntu. I've read that cmxl should find the right encoding. For me removing the encoding option solves the problem.