### PR TITLE
shoveling strings, commenting inline

### DIFF
--- a/lib/fints/mt535_miniparser.rb
+++ b/lib/fints/mt535_miniparser.rb
@@ -61,13 +61,13 @@ module FinTS
           total_value: total_value
         }
       end
-          
+
       retval
     end
 
     def collapse_multilines(lines)
       clauses = []
-      prevline = ''
+      prevline = ""
       lines.each do |line|
         if line.start_with?(':')
           clauses << prevline if prevline != ''
@@ -77,7 +77,7 @@ module FinTS
           clauses << prevline
           clauses << line
         else
-          prevline += "|#{line}"
+          prevline << "|#{line}"
         end
       end
       clauses

--- a/lib/fints/mt535_miniparser.rb
+++ b/lib/fints/mt535_miniparser.rb
@@ -88,16 +88,13 @@ module FinTS
       stack = []
       within_financial_instrument = false
       clauses.each do |clause|
-        if clause.start_with?(':16R:FIN')
-          # start of financial instrument
+        if clause.start_with?(':16R:FIN') # start of financial instrument
           within_financial_instrument = true
-        elsif clause.startswith(':16S:FIN')
-          # end of financial instrument - move stack over to
-          # return value
-          retval << stack
-          stack = []
+        elsif clause.startswith(':16S:FIN') # end of financial instrument
+          retval << stack # store stack
+          stack = [] # empty stack for next operation
           within_financial_instrument = false
-        elsif within_financial_instrument
+        elsif within_financial_instrument # everything inbetween
           stack << clause
         end
       end


### PR DESCRIPTION
shoveling is faster, I cleaned up `grab_financial_instrument_segments\1`, too. Maybe the plus operator was necessary, I didn't see any buggy behavior 👍 